### PR TITLE
Make ECR endpoint into an env variable

### DIFF
--- a/deploy/build.js
+++ b/deploy/build.js
@@ -39,12 +39,12 @@ moduleRootFolders.forEach(moduleRoot => {
 
 let dockerImageLabel = specialBranches.includes(process.env.TRAVIS_BRANCH) ? process.env.TRAVIS_BRANCH : process.env.TRAVIS_BUILD_ID || 'latest';
 try {
-  process.stdout.write(`Retrieving docker build from 680542703984.dkr.ecr.us-east-1.amazonaws.com/cardboard:${dockerImageLabel} ...`);
-  execSync(`docker pull 680542703984.dkr.ecr.us-east-1.amazonaws.com/cardboard:${dockerImageLabel}`);
+  process.stdout.write(`Retrieving docker build from ${process.env.ECR_ENDPOINT}:${dockerImageLabel} ...`);
+  execSync(`docker pull ${process.env.ECR_ENDPOINT}:${dockerImageLabel}`);
 } catch (err) {
   if (!/manifest.*not found/.test(err.message)) {
     throw err;
   }
   process.stdout.write(`No build cache found for cardboard:${dockerImageLabel}, building from scratch.`);
 }
-execSync(`docker build -f ${join(context, 'Dockerfile')} --cache-from 680542703984.dkr.ecr.us-east-1.amazonaws.com/cardboard:${dockerImageLabel} -t cardboard ${context}`, { stdio: 'inherit' });
+execSync(`docker build -f ${join(context, 'Dockerfile')} --cache-from ${process.env.ECR_ENDPOINT}:${dockerImageLabel} -t cardboard ${context}`, { stdio: 'inherit' });

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -27,6 +27,7 @@ if [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
                   LOG_LEVELS \
                   GIT_PRIVATE_KEY \
                   GIT_BRANCH_PREFIX \
+                  ECR_ENDPOINT \
                   CARDSTACK_SESSIONS_KEY; do
       command="export ${variable}=\$${target_env}_${variable}"
       eval $command
@@ -41,7 +42,7 @@ if [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
   export TARGET_ENV="cardboard-$target_env"
 
   # This needs to be exported because our docker-compose.yml below is interpolating it
-  export CONTAINER_REPO=680542703984.dkr.ecr.us-east-1.amazonaws.com/cardboard
+  export CONTAINER_REPO=ECR_ENDPOINT
 
   export INITIAL_DATA_DIR=/srv/hub/cardboard/cardstack
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - GITHUB_CLIENT_SECRET
       - GITHUB_TOKEN
       - WEBHOOK_URL
+      - ECR_ENDPOINT
 
 networks:
   default:


### PR DESCRIPTION
I added `ECR_ENDPOINT` as an environment variable in Travis, with a value of `680542703984.dkr.ecr.us-east-1.amazonaws.com/cardboard`, which was previously hard-coded in the deploy scripts.

The real purpose of this PR is to see if the same changes I made to `project-template` would be valid, if it was deployed: https://github.com/cardstack/project-template/pull/32

I'm not sure how else to review this besides trying it. It should have a look from someone who knows Docker well.